### PR TITLE
Реализован Diff просчет flex компоновки пользовательского интерфейса

### DIFF
--- a/quite.pro
+++ b/quite.pro
@@ -17,7 +17,7 @@ win32-msvc* {
 }
 
 SOURCES += src/main.cpp
-SOURCES += src/ui/flex/flexnode.cpp
+SOURCES += src/objects/flexnode.cpp
 SOURCES += src/objects/invoke.cpp
 SOURCES += src/ui/base/diffcounter.cpp
 SOURCES += src/ui/components/windowcomponent.cpp
@@ -49,7 +49,7 @@ SOURCES += src/events/importmodule.cpp
 SOURCES += src/events/throwerror.cpp
 
 HEADERS += src/base/engine.h
-HEADERS += src/ui/flex/flexnode.h
+HEADERS += src/objects/flexnode.h
 HEADERS += src/objects/invoke.h
 HEADERS += src/ui/base/diffcounter.h
 HEADERS += src/ui/components/windowcomponent.h

--- a/src/objects/flexnode.cpp
+++ b/src/objects/flexnode.cpp
@@ -396,6 +396,18 @@ int FlexNode::getWidth() const {
 
 /*---------------------------------------------------------------------------*/
 
+int FlexNode::getMarginLeft() const {
+    return static_cast<int>(YGNodeStyleGetMargin(node,YGEdgeLeft).value);
+}
+
+/*---------------------------------------------------------------------------*/
+
+int FlexNode::getMarginTop() const {
+    return static_cast<int>(YGNodeStyleGetMargin(node,YGEdgeTop).value);
+}
+
+/*---------------------------------------------------------------------------*/
+
 int FlexNode::getLastTop() const {
     return lastTop;
 }

--- a/src/objects/flexnode.cpp
+++ b/src/objects/flexnode.cpp
@@ -97,6 +97,14 @@ void FlexNode::buildTree() {
 
 /*---------------------------------------------------------------------------*/
 
+void FlexNode::calculateLayoutLtr(int T, int L, int H, int W) {
+    YGNodeStyleSetPosition(node,YGEdgeTop,static_cast<int>(T));
+    YGNodeStyleSetPosition(node,YGEdgeLeft,static_cast<int>(L));
+    calculateLayoutLtr(H,W);
+}
+
+/*---------------------------------------------------------------------------*/
+
 void FlexNode::appendChild(FlexNode *child) {
     qDebug() << "FlexNode appendChild";
     childCount++;
@@ -332,10 +340,10 @@ void FlexNode::parseOtherProps() {
 
 /*---------------------------------------------------------------------------*/
 
-void FlexNode::commitNewPos(int T, int L) {
-    int top = getLayoutTop() + T;
+void FlexNode::commitNewPos() {
+    int top = getLayoutTop();
     int bottom = getLayoutBottom();
-    int left = getLayoutLeft() + L;
+    int left = getLayoutLeft();
     int right = getLayoutRight();
     int height = getLayoutHeight();
     int width = getLayoutWidth();
@@ -354,11 +362,11 @@ void FlexNode::commitNewPos(int T, int L) {
 
 /*---------------------------------------------------------------------------*/
 
-void FlexNode::commitChildNewPos(int T, int L) {
-    commitNewPos(T, L);
+void FlexNode::commitChildNewPos() {
+    commitNewPos();
     QLinkedList<FlexNode*>::iterator iter;
     for (iter=child.begin();iter!=child.end();iter++) {
-        (*iter)->commitChildNewPos(T, L);
+        (*iter)->commitChildNewPos();
     }
 }
 
@@ -396,18 +404,6 @@ int FlexNode::getLastTop() const {
 
 int FlexNode::getLastLeft() const {
     return lastLeft;
-}
-
-/*---------------------------------------------------------------------------*/
-
-int FlexNode::getPaddingTop() const {
-    return static_cast<int>(YGNodeStyleGetPadding(node,YGEdgeTop).value);
-}
-
-/*---------------------------------------------------------------------------*/
-
-int FlexNode::getPaddingLeft() const {
-    return static_cast<int>(YGNodeStyleGetPadding(node,YGEdgeLeft).value);
 }
 
 /*****************************************************************************/
@@ -996,7 +992,7 @@ int FlexNode::getWidth() {
  * при инкрементальном пересчете поддрева, когда мы считаем компоновку только
  * изменившегося компонента.
  */
-void FlexNode::calculateLayoutLtr(int T,int L, int PT, int PL, int H,int W) {
+void FlexNode::calculateLayoutLtr(int H,int W) {
     YGNodeCalculateLayout(
         node,
         static_cast<float>(W),
@@ -1006,10 +1002,10 @@ void FlexNode::calculateLayoutLtr(int T,int L, int PT, int PL, int H,int W) {
     /*
      * Родительский элемент не сдвигается по базису
      */
-    commitNewPos(T,L);
+    commitNewPos();
     QLinkedList<FlexNode*>::iterator iter;
     for (iter=child.begin();iter!=child.end();iter++) {
-        (*iter)->commitChildNewPos(T+PT,L+PL);
+        (*iter)->commitChildNewPos();
     }
 }
 

--- a/src/objects/flexnode.cpp
+++ b/src/objects/flexnode.cpp
@@ -362,6 +362,54 @@ void FlexNode::commitChildNewPos(int T, int L) {
     }
 }
 
+/*---------------------------------------------------------------------------*/
+
+void FlexNode::setLastLeft(int left) {
+    lastLeft=left;
+}
+
+/*---------------------------------------------------------------------------*/
+
+void FlexNode::setLastTop(int top) {
+    lastTop=top;
+}
+
+/*---------------------------------------------------------------------------*/
+
+int FlexNode::getHeight() const{
+    return static_cast<int>(YGNodeStyleGetHeight(node).value);
+}
+
+/*---------------------------------------------------------------------------*/
+
+int FlexNode::getWidth() const {
+    return static_cast<int>(YGNodeStyleGetWidth(node).value);
+}
+
+/*---------------------------------------------------------------------------*/
+
+int FlexNode::getLastTop() const {
+    return lastTop;
+}
+
+/*---------------------------------------------------------------------------*/
+
+int FlexNode::getLastLeft() const {
+    return lastLeft;
+}
+
+/*---------------------------------------------------------------------------*/
+
+int FlexNode::getPaddingTop() const {
+    return static_cast<int>(YGNodeStyleGetPadding(node,YGEdgeTop).value);
+}
+
+/*---------------------------------------------------------------------------*/
+
+int FlexNode::getPaddingLeft() const {
+    return static_cast<int>(YGNodeStyleGetPadding(node,YGEdgeLeft).value);
+}
+
 /*****************************************************************************/
 
 void FlexNode::setFlexGrow(int v) {
@@ -948,7 +996,7 @@ int FlexNode::getWidth() {
  * при инкрементальном пересчете поддрева, когда мы считаем компоновку только
  * изменившегося компонента.
  */
-void FlexNode::calculateLayoutLtr(int T,int L,int H,int W) {
+void FlexNode::calculateLayoutLtr(int T,int L, int PT, int PL, int H,int W) {
     YGNodeCalculateLayout(
         node,
         static_cast<float>(W),
@@ -958,26 +1006,10 @@ void FlexNode::calculateLayoutLtr(int T,int L,int H,int W) {
     /*
      * Родительский элемент не сдвигается по базису
      */
-    commitNewPos(0,0);
+    commitNewPos(T,L);
     QLinkedList<FlexNode*>::iterator iter;
     for (iter=child.begin();iter!=child.end();iter++) {
-        (*iter)->commitChildNewPos(T,L);
-    }
-}
-
-/*---------------------------------------------------------------------------*/
-
-void FlexNode::calculateLayoutRtl(int T,int L,int H,int W) {
-    YGNodeCalculateLayout(
-        node,
-        static_cast<float>(W),
-        static_cast<float>(H),
-        YGDirectionRTL
-    );
-    commitNewPos(0,0);
-    QLinkedList<FlexNode*>::iterator iter;
-    for (iter=child.begin();iter!=child.end();iter++) {
-        (*iter)->commitChildNewPos(T,L);
+        (*iter)->commitChildNewPos(T+PT,L+PL);
     }
 }
 

--- a/src/objects/flexnode.h
+++ b/src/objects/flexnode.h
@@ -39,7 +39,8 @@ class FlexNode : public QObject {
     void printTree();
     QString nodeInfo();
     void buildTree();
-    void calculateLayoutLtr(int T,int L, int PT, int PL, int H,int W);
+    void calculateLayoutLtr(int T,int L, int H,int W);
+    void calculateLayoutLtr(int H,int W);
     void appendChild(FlexNode* child);
   public:
     YGNodeRef getNode() const;
@@ -53,8 +54,8 @@ class FlexNode : public QObject {
     void parseFlexWrap(QString wrap);
     void parseOtherProps();
   private:
-    void commitNewPos(int T, int L);
-    void commitChildNewPos(int T, int L);
+    void commitNewPos();
+    void commitChildNewPos();
   public:
     /* diff update getters */
     void setLastTop(int top);
@@ -63,8 +64,6 @@ class FlexNode : public QObject {
     int getWidth() const;
     int getLastTop() const;
     int getLastLeft() const;
-    int getPaddingTop() const;
-    int getPaddingLeft() const;
     /* flex */
     void setFlexGrow(int v);
     void setFlexShrink(int v);

--- a/src/objects/flexnode.h
+++ b/src/objects/flexnode.h
@@ -25,6 +25,8 @@ class FlexNode : public QObject {
   private:
     YGNodeRef node;
     bool fill=false;
+    int lastTop=-1;
+    int lastLeft=-1;
   private:
     QQuickItem* item;
     QLinkedList<FlexNode*> child;
@@ -37,8 +39,7 @@ class FlexNode : public QObject {
     void printTree();
     QString nodeInfo();
     void buildTree();
-    void calculateLayoutLtr(int T=0,int L=0,int H=0,int W=0);
-    Q_DECL_DEPRECATED void calculateLayoutRtl(int T=0,int L=0,int H=0,int W=0);
+    void calculateLayoutLtr(int T,int L, int PT, int PL, int H,int W);
     void appendChild(FlexNode* child);
   public:
     YGNodeRef getNode() const;
@@ -55,6 +56,15 @@ class FlexNode : public QObject {
     void commitNewPos(int T, int L);
     void commitChildNewPos(int T, int L);
   public:
+    /* diff update getters */
+    void setLastTop(int top);
+    void setLastLeft(int left);
+    int getHeight() const;
+    int getWidth() const;
+    int getLastTop() const;
+    int getLastLeft() const;
+    int getPaddingTop() const;
+    int getPaddingLeft() const;
     /* flex */
     void setFlexGrow(int v);
     void setFlexShrink(int v);

--- a/src/objects/flexnode.h
+++ b/src/objects/flexnode.h
@@ -16,8 +16,7 @@
 using namespace Quite::Ui::Components;
 
 namespace Quite {
-namespace Ui {
-namespace Flex {
+namespace Objects {
 
 /*****************************************************************************/
 
@@ -38,8 +37,8 @@ class FlexNode : public QObject {
     void printTree();
     QString nodeInfo();
     void buildTree();
-    void calculateLayoutLtr();
-    void calculateLayoutRtl();
+    void calculateLayoutLtr(int T=0,int L=0,int H=0,int W=0);
+    Q_DECL_DEPRECATED void calculateLayoutRtl(int T=0,int L=0,int H=0,int W=0);
     void appendChild(FlexNode* child);
   public:
     YGNodeRef getNode() const;
@@ -53,8 +52,8 @@ class FlexNode : public QObject {
     void parseFlexWrap(QString wrap);
     void parseOtherProps();
   private:
-    void commitNewPos();
-    void commitChildNewPos();
+    void commitNewPos(int T, int L);
+    void commitChildNewPos(int T, int L);
   public:
     /* flex */
     void setFlexGrow(int v);
@@ -157,8 +156,7 @@ class FlexNode : public QObject {
 
 /*****************************************************************************/
 
-} // namespace Flex
-} // namespace Ui
+} // namespace Objects
 } // namespace Quite
 
 #endif // FLEXNODE_H

--- a/src/objects/flexnode.h
+++ b/src/objects/flexnode.h
@@ -62,8 +62,10 @@ class FlexNode : public QObject {
     void setLastLeft(int left);
     int getHeight() const;
     int getWidth() const;
-    int getLastTop() const;
+    int getMarginLeft() const;
+    int getMarginTop() const;
     int getLastLeft() const;
+    int getLastTop() const;
     /* flex */
     void setFlexGrow(int v);
     void setFlexShrink(int v);

--- a/src/ui/base/componentnode.cpp
+++ b/src/ui/base/componentnode.cpp
@@ -223,11 +223,11 @@ bool ComponentNode::tryInsertAfterChild(
     int lastIndex
 ) {
     qDebug() << "ComponentNode tryInsertAfterChild";
-    auto afterIndex = static_cast<unsigned long long>(lastIndex)-1;
-    if (merged[afterIndex].parent==child.parent) {
+    auto index = static_cast<unsigned long long>(lastIndex)-1;
+    if ((!merged[index].newTree)&&merged[index].parent==child.parent){
         incrementResolveCounter();
-        merged[afterIndex].parent->node->insertAfterChild(
-            merged[afterIndex].node,
+        merged[index].parent->node->insertAfterChild(
+            merged[index].node,
             child.node
         );
         return true;

--- a/src/ui/base/diffcounter.cpp
+++ b/src/ui/base/diffcounter.cpp
@@ -39,6 +39,14 @@ void DiffCounter::decrementCounter() {
     locker.lock();
     if (resolveCounter==0) {
         qCritical() << "DiffCounter decrementCounter < 0";
+    } else if (resolveCounter==1) {
+        resolveCounter--;
+        /* Нужен асинхронных запуск, чтобы разблокировать мьютекс */
+        QMetaObject::invokeMethod(
+            this,
+            "diffFree",
+            Qt::QueuedConnection
+        );
     } else {
         resolveCounter--;
     }

--- a/src/ui/base/diffcounter.h
+++ b/src/ui/base/diffcounter.h
@@ -28,6 +28,8 @@ class DiffCounter : public QObject {
     bool changesResolved();
   public:
     static DiffCounter* instance();
+  signals:
+    void diffFree();
 };
 
 /*****************************************************************************/

--- a/src/ui/base/element.cpp
+++ b/src/ui/base/element.cpp
@@ -329,9 +329,9 @@ void Element::updateLayoutNow() {
     qDebug() << "Element updateLayoutNow";
     int H=layout->getWidth();
     int W=layout->getHeight();
-    int T=layout->getLayoutTop();
+    int T=layout->getLayoutTop()-layout->getMarginTop();
     int LT=layout->getLastTop();
-    int L=layout->getLayoutLeft();
+    int L=layout->getLayoutLeft()-layout->getMarginLeft();
     int LL=layout->getLastLeft();
 
     //layout->deleteLater();

--- a/src/ui/base/element.cpp
+++ b/src/ui/base/element.cpp
@@ -97,13 +97,7 @@ void Element::childInsertAfter(Node *after, Element *child) {
                 this,
                 SLOT(childDiffDeleteHandler())
             );
-            connect(
-                child,
-                SIGNAL(update()),
-                this,
-                SIGNAL(update())
-            );
-            emit update();
+            updateLayout();
             return;
         } else {
             elemIter++;
@@ -131,13 +125,7 @@ void Element::childAppend(Element *child) {
         this,
         SLOT(childDiffDeleteHandler())
     );
-    connect(
-        child,
-        SIGNAL(update()),
-        this,
-        SIGNAL(update())
-    );
-    emit update();
+    updateLayout();
 }
 
 /*---------------------------------------------------------------------------*/
@@ -145,13 +133,7 @@ void Element::childAppend(Element *child) {
 void Element::childDeleted(Element *child) {
     qDebug() << "Element default childDeleted";
     this->child.removeOne(child);
-    disconnect(
-        child,
-        SIGNAL(update()),
-        this,
-        SIGNAL(update())
-    );
-    emit update();
+    updateLayout();
 }
 
 /*---------------------------------------------------------------------------*/
@@ -174,14 +156,8 @@ void Element::childChanged() {
             this,
             SLOT(childDiffDeleteHandler())
         );
-        connect(
-            element,
-            SIGNAL(update()),
-            this,
-            SIGNAL(update())
-        );
     }
-    emit update();
+    updateLayout();
 }
 
 /*---------------------------------------------------------------------------*/
@@ -245,7 +221,7 @@ void Element::propsChangedHandler(
     if (merge) {
         propsChanged();
         DiffCounter::instance()->decrementCounter();
-        emit update();
+        updateLayout();
     } else {
         propsChanged();
     }
@@ -289,7 +265,7 @@ void Element::childDiffDeleteHandler() {
     );
     childDeletedHandler(sender);
     DiffCounter::instance()->decrementCounter();
-    emit update();
+    updateLayout();
 }
 
 /*---------------------------------------------------------------------------*/
@@ -302,14 +278,13 @@ void Element::diffDeleteEmit() {
 /*---------------------------------------------------------------------------*/
 
 FlexNode *Element::buildFlexTree(bool fill) {
-    if (layout==nullptr) {
-        layout->deleteLater();
-    }
     layout = new FlexNode(getItem(),fill);
     QLinkedList<Element*> child=getChild();
     QLinkedList<Element*>::iterator iter;
     for (iter=child.begin();iter!=child.end();iter++) {
         layout->appendChild((*iter)->buildFlexTree(false));
+        /* layout инициализирован, позволяем рисовать */
+        (*iter)->startLayoutUpdate();
     }
     return layout;
 }
@@ -320,7 +295,10 @@ void Element::updateLayout() {
       qDebug() << "Element updateLayout";
       DiffCounter* instance = DiffCounter::instance();
       bool resolved = instance->changesResolved();
-      if (layoutUpdateScheduled&&!resolved) {
+      if (!layoutUpdateStarted) {
+          qDebug() << "Element updateLayout not started";
+          return;
+      } else if (layoutUpdateScheduled&&!resolved) {
           qDebug() << "Element updateLayout skip";
           return;
       } else if (layoutUpdateScheduled&&resolved) {
@@ -340,21 +318,40 @@ void Element::updateLayout() {
 
 /*---------------------------------------------------------------------------*/
 
+void Element::startLayoutUpdate() {
+    qDebug() << "Element startLayoutUpdate";
+    layoutUpdateStarted=true;
+}
+
+/*---------------------------------------------------------------------------*/
+
 void Element::updateLayoutNow() {
     qDebug() << "Element updateLayoutNow";
-    int H=getItem()->property("height").toInt();
-    int W=getItem()->property("width").toInt();
-    int T=getItem()->property("y").toInt();
-    int L=getItem()->property("x").toInt();
-    if (layout!=nullptr) {
-        layout->deleteLater();
-        layout = buildFlexTree();
+    int H=layout->getWidth();
+    int W=layout->getHeight();
+    int T=layout->getLayoutTop();
+    int LT=layout->getLastTop();
+    int PT=layout->getPaddingTop();
+    int L=layout->getLayoutLeft();
+    int LL=layout->getLastLeft();
+    int PL=layout->getPaddingLeft();
+
+    //layout->deleteLater();
+    layout=buildFlexTree();
+
+    if (LL==-1&&LT==-1) {
+        layout->setLastTop(T);
+        layout->setLastLeft(L);
     } else {
-        layout = buildFlexTree();
+        Q_ASSERT(LL!=-1);
+        Q_ASSERT(LT!=-1);
+        T=LT;
+        L=LL;
     }
+
     layout->printTree();
     layout->buildTree();
-    layout->calculateLayoutLtr(T,L,H,W);
+    layout->calculateLayoutLtr(T,L,PT,PL,H,W);
 }
 
 /*****************************************************************************/

--- a/src/ui/base/element.cpp
+++ b/src/ui/base/element.cpp
@@ -331,10 +331,8 @@ void Element::updateLayoutNow() {
     int W=layout->getHeight();
     int T=layout->getLayoutTop();
     int LT=layout->getLastTop();
-    int PT=layout->getPaddingTop();
     int L=layout->getLayoutLeft();
     int LL=layout->getLastLeft();
-    int PL=layout->getPaddingLeft();
 
     //layout->deleteLater();
     layout=buildFlexTree();
@@ -351,7 +349,7 @@ void Element::updateLayoutNow() {
 
     layout->printTree();
     layout->buildTree();
-    layout->calculateLayoutLtr(T,L,PT,PL,H,W);
+    layout->calculateLayoutLtr(T,L,H,W);
 }
 
 /*****************************************************************************/

--- a/src/ui/base/element.h
+++ b/src/ui/base/element.h
@@ -34,8 +34,10 @@ class Element : public QObject {
     Node* node;
   private:
     QQuickItem* item;
-  private:
+  protected:
     FlexNode* layout=nullptr;
+  private:
+    bool layoutUpdateStarted=false;
     bool layoutUpdateScheduled=false;
   public:
     Element(QUrl uri, Node* node, QQmlEngine* engine, Element* parent);
@@ -110,12 +112,20 @@ class Element : public QObject {
     void updateLayout();
 
   /*
+   * Вызывается окном и позволяет элементу начать считать diff flexbox
+   */
+  public:
+    void startLayoutUpdate();
+
+  /*
    * Подразумевается, что updateLayout() может пропустить перерисовку,
    * так как не все изменения diff древа применены. Этот метод
    * гарантированно выполнит перерасчет.
+   *
+   * Переопределяется у окна для инициализации просчета дерева
    */
   protected:
-    void updateLayoutNow();
+    virtual void updateLayoutNow();
 
   /*
    * Сигналы для Manager, чтобы рендерить элементы
@@ -129,7 +139,6 @@ class Element : public QObject {
    * Сигнал для уведомления о изменении свойств/потомков
    */
   signals:
-    void update();
     void diffDelete();
 };
 

--- a/src/ui/elements/window.cpp
+++ b/src/ui/elements/window.cpp
@@ -81,7 +81,6 @@ void Window::updateLayoutNow() {
         layout->printTree();
         layout->buildTree();
         layout->calculateLayoutLtr(
-            0,0,0,0,
             window->getHeight(),
             window->getWidth()
         );

--- a/src/ui/elements/window.cpp
+++ b/src/ui/elements/window.cpp
@@ -36,6 +36,7 @@ Window::Window(Node *node, QQmlEngine *engine, Element *parent)
             this,
             SLOT(updateLayout())
         );
+        startLayoutUpdate();
         /*
          * Default props place
          */
@@ -66,8 +67,28 @@ FlexNode* Window::buildFlexTree(bool fill) {
         layout->appendChild((*iter)->buildFlexTree(
             false
         ));
+        (*iter)->startLayoutUpdate();
     }
     return layout;
+}
+
+/*---------------------------------------------------------------------------*/
+
+void Window::updateLayoutNow() {
+    qDebug() << "Window updateLayoutNow";
+    if (!initialRenderComplete) {
+        layout=buildFlexTree();
+        layout->printTree();
+        layout->buildTree();
+        layout->calculateLayoutLtr(
+            0,0,0,0,
+            window->getHeight(),
+            window->getWidth()
+        );
+        initialRenderComplete=true;
+    } else {
+        Element::updateLayoutNow();
+    }
 }
 
 /*****************************************************************************/

--- a/src/ui/elements/window.cpp
+++ b/src/ui/elements/window.cpp
@@ -28,13 +28,13 @@ Window::Window(Node *node, QQmlEngine *engine, Element *parent)
             this,
             SIGNAL(update()),
             this,
-            SLOT(updateFlexLayout())
+            SLOT(updateLayout())
         );
         connect(
             window,
             SIGNAL(resize()),
             this,
-            SLOT(updateFlexLayout())
+            SLOT(updateLayout())
         );
         /*
          * Default props place
@@ -52,48 +52,22 @@ Window::~Window() {
 
 /*---------------------------------------------------------------------------*/
 
-FlexNode *Window::buildFlexTree(Element *current,bool fill) {
-    FlexNode* node = new FlexNode(current->getItem(),fill);
-    QLinkedList<Element*> child=current->getChild();
+FlexNode* Window::buildFlexTree(bool fill) {
+    qDebug() << "Window updateLayout";
+    Q_UNUSED(fill);
+    FlexNode* layout = new FlexNode(
+        getItem(),
+        window->getHeight(),
+        window->getWidth()
+    );
+    QLinkedList<Element*> child=getChild();
     QLinkedList<Element*>::iterator iter;
     for (iter=child.begin();iter!=child.end();iter++) {
-        node->appendChild(buildFlexTree(
-            *iter,
-            qobject_cast<Component*>(current)!=nullptr
+        layout->appendChild((*iter)->buildFlexTree(
+            false
         ));
     }
-    return node;
-}
-
-/*---------------------------------------------------------------------------*/
-
-void Window::updateFlexLayout() {
-    qDebug() << "Window updateFlexLayout";
-    if (!DiffCounter::instance()->changesResolved()) {
-        qDebug() << "Window updateFlexLayout not ready";
-    } else {
-        qDebug() << "Window updateFlexLayout ready";
-        FlexNode* windowNode;
-        {
-            windowNode = new FlexNode(
-                getItem(),
-                window->getHeight(),
-                window->getWidth()
-            );
-            QLinkedList<Element*> child=getChild();
-            QLinkedList<Element*>::iterator iter;
-            for (iter=child.begin();iter!=child.end();iter++) {
-                windowNode->appendChild(buildFlexTree(
-                    *iter,
-                    qobject_cast<Component*>(*iter)!=nullptr
-                ));
-            }
-        }
-        windowNode->printTree();
-        windowNode->buildTree();
-        windowNode->calculateLayoutLtr();
-        windowNode->deleteLater();
-    }
+    return layout;
 }
 
 /*****************************************************************************/

--- a/src/ui/elements/window.h
+++ b/src/ui/elements/window.h
@@ -24,6 +24,7 @@ class Window : public Element {
   Q_OBJECT
   private:
     WindowComponent* window;
+    bool initialRenderComplete=false;
   public:
     Window(Node* node, QQmlEngine* engine, Element* parent);
     virtual ~Window() override;
@@ -32,7 +33,14 @@ class Window : public Element {
    * Переопределение перерисовки с передачей размера окна
    */
   public slots:
-    virtual FlexNode* buildFlexTree(bool fill) override;
+    virtual FlexNode* buildFlexTree(bool fill=false) override;
+
+  /*
+   * Переопределение для создания инициализирующего древа
+   * компоновки
+   */
+  protected:
+    virtual void updateLayoutNow() override;
 
   signals:
     void closed();

--- a/src/ui/elements/window.h
+++ b/src/ui/elements/window.h
@@ -7,12 +7,10 @@
 
 #include "src/ui/component.h"
 #include "src/ui/base/element.h"
-#include "src/ui/flex/flexnode.h"
 #include "src/ui/base/diffcounter.h"
 #include "src/ui/components/windowcomponent.h"
 
 using namespace Quite::Ui;
-using namespace Quite::Ui::Flex;
 using namespace Quite::Ui::Base;
 using namespace Quite::Ui::Components;
 
@@ -29,15 +27,12 @@ class Window : public Element {
   public:
     Window(Node* node, QQmlEngine* engine, Element* parent);
     virtual ~Window() override;
-  private:
-    FlexNode* buildFlexTree(Element* current,bool fill=false);
 
   /*
-   * Слот для изменения компоновки флексбокс при обновлении дочерних
-   * элементов
+   * Переопределение перерисовки с передачей размера окна
    */
-  private slots:
-    void updateFlexLayout();
+  public slots:
+    virtual FlexNode* buildFlexTree(bool fill) override;
 
   signals:
     void closed();

--- a/test/diff-push-pop-diff-flex.js
+++ b/test/diff-push-pop-diff-flex.js
@@ -1,0 +1,55 @@
+function SampleComponent(props) {
+    console.log("SampleComponent ctor");
+    this.state={
+        rects:[]
+    }
+}
+
+SampleComponent.prototype.render=function() {
+    return Quite.createElement("Rectangle", {color: "white", flexDirection: "column", marginTop: 5, marginLeft: 5},
+        Quite.createElement("Rectangle", {height: 55, color: "whitesmoke", flexDirection: "row", minHeight: 50, paddingTop: 5},
+            Quite.createElement("Button", {text: "Add rect", height: 50, width: 125, marginRight:5, onClick: this.addRect}),
+            Quite.createElement("Button", {text: "Remove rect", height: 50, width: 125, onClick: this.removeRect}),
+        ), 
+        Quite.createElement("Rectangle", {color: "cyan", flexDirection: "column", minHeight: 150, minWidth: 150},
+            this.state.rects.map((_, index)=>Quite.createElement("Rectangle", {
+                        key: index+1,
+                        height: 50, 
+                        width: 50, 
+                        color: "cyan", 
+                        marginRight: 5
+                    },
+                Quite.createElement("Rectangle", {key:59,minHeight:15, minWidth:15, color:"red"},
+                    Quite.createElement("Rectangle", {key:60,minHeight:15, minWidth:15, color:"red"}),
+                    Quite.createElement("Rectangle", {key:61,minHeight:15, minWidth:15, color:"red"}),
+                    Quite.createElement("Rectangle", {key:62,minHeight:15, minWidth:15, color:"red"},
+                        Quite.createElement("Rectangle", {key:63,minHeight:15, minWidth:15, color:"red"})
+                    )
+                ),
+                Quite.createElement("Rectangle", {key: 88, minHeight:63, minWidth:15, color:"red"})
+            ))
+        ),
+    );
+}
+
+SampleComponent.prototype.addRect=function() {
+    console.log("addRect")
+    this.setState({
+        rects:this.state.rects.concat([1])
+    })
+}
+
+SampleComponent.prototype.removeRect=function() {
+    console.log("removeRect")
+    const rects=this.state.rects.reverse().slice(1).reverse();
+    console.log(JSON.stringify(rects));
+    this.setState({rects})
+}
+
+function test() {
+    return  Quite.createElement("Window", null,
+        Quite.createElement(SampleComponent, {heightPercent: 100, widthPercent: 100})
+    );
+}
+
+Quite.render(test());

--- a/test/diff-push-pop-diff-flex.js
+++ b/test/diff-push-pop-diff-flex.js
@@ -13,13 +13,12 @@ SampleComponent.prototype.render=function() {
         ), 
         Quite.createElement("Rectangle", {color: "red", flexDirection: "column", marginTop: 5, flexWrap: "wrap", minHeight: 180, minWidth: 180},
             this.state.rects.map((_, index)=>Quite.createElement("Rectangle", {
-                        key: index,
-                        height: 50, 
-                        width: 50, 
-                        color: "green", 
-                        margin: 5
-            }
-            ))
+                key: index,
+                height: 50, 
+                width: 50, 
+                color: "green", 
+                margin: 5
+            }))
         ),
     );
 }
@@ -27,7 +26,7 @@ SampleComponent.prototype.render=function() {
 SampleComponent.prototype.addRect=function() {
     console.log("addRect")
     this.setState({
-        rects:this.state.rects.concat([1])
+        rects:this.state.rects.concat([1, 1])
     })
 }
 

--- a/test/diff-push-pop-diff-flex.js
+++ b/test/diff-push-pop-diff-flex.js
@@ -11,22 +11,14 @@ SampleComponent.prototype.render=function() {
             Quite.createElement("Button", {text: "Add rect", height: 50, width: 125, marginRight:5, onClick: this.addRect}),
             Quite.createElement("Button", {text: "Remove rect", height: 50, width: 125, onClick: this.removeRect}),
         ), 
-        Quite.createElement("Rectangle", {color: "red", flexDirection: "column", minHeight: 150, minWidth: 150},
+        Quite.createElement("Rectangle", {color: "red", flexDirection: "column", marginTop: 5, flexWrap: "wrap", minHeight: 180, minWidth: 180},
             this.state.rects.map((_, index)=>Quite.createElement("Rectangle", {
-                        key: index+1,
+                        key: index,
                         height: 50, 
                         width: 50, 
                         color: "green", 
-                        marginRight: 5
-            }/*,
-                Quite.createElement("Rectangle", {key:59,minHeight:15, minWidth:15, color:"red"},
-                    Quite.createElement("Rectangle", {key:60,minHeight:15, minWidth:15, color:"red"}),
-                    Quite.createElement("Rectangle", {key:61,minHeight:15, minWidth:15, color:"red"}),
-                    Quite.createElement("Rectangle", {key:62,minHeight:15, minWidth:15, color:"red"},
-                        Quite.createElement("Rectangle", {key:63,minHeight:15, minWidth:15, color:"red"})
-                    )
-                ),
-                Quite.createElement("Rectangle", {key: 88, minHeight:63, minWidth:15, color:"red"})*/
+                        margin: 5
+            }
             ))
         ),
     );

--- a/test/diff-push-pop-diff-flex.js
+++ b/test/diff-push-pop-diff-flex.js
@@ -6,19 +6,19 @@ function SampleComponent(props) {
 }
 
 SampleComponent.prototype.render=function() {
-    return Quite.createElement("Rectangle", {color: "white", flexDirection: "column", marginTop: 5, marginLeft: 5},
+    return Quite.createElement("Rectangle", {color: "yellow", flexDirection: "column", marginTop: 5, marginLeft: 5},
         Quite.createElement("Rectangle", {height: 55, color: "whitesmoke", flexDirection: "row", minHeight: 50, paddingTop: 5},
             Quite.createElement("Button", {text: "Add rect", height: 50, width: 125, marginRight:5, onClick: this.addRect}),
             Quite.createElement("Button", {text: "Remove rect", height: 50, width: 125, onClick: this.removeRect}),
         ), 
-        Quite.createElement("Rectangle", {color: "cyan", flexDirection: "column", minHeight: 150, minWidth: 150},
+        Quite.createElement("Rectangle", {color: "red", flexDirection: "column", minHeight: 150, minWidth: 150},
             this.state.rects.map((_, index)=>Quite.createElement("Rectangle", {
                         key: index+1,
                         height: 50, 
                         width: 50, 
-                        color: "cyan", 
+                        color: "green", 
                         marginRight: 5
-                    },
+            }/*,
                 Quite.createElement("Rectangle", {key:59,minHeight:15, minWidth:15, color:"red"},
                     Quite.createElement("Rectangle", {key:60,minHeight:15, minWidth:15, color:"red"}),
                     Quite.createElement("Rectangle", {key:61,minHeight:15, minWidth:15, color:"red"}),
@@ -26,7 +26,7 @@ SampleComponent.prototype.render=function() {
                         Quite.createElement("Rectangle", {key:63,minHeight:15, minWidth:15, color:"red"})
                     )
                 ),
-                Quite.createElement("Rectangle", {key: 88, minHeight:63, minWidth:15, color:"red"})
+                Quite.createElement("Rectangle", {key: 88, minHeight:63, minWidth:15, color:"red"})*/
             ))
         ),
     );


### PR DESCRIPTION
Теперь пересчет компоновки только у элементов с обновленными потомками. Исправление в подстановку потомков tryInsertAfterChild - работало ранее при добавлении не более одного элемента, так как пропустил проверку на виртуальное древо. Теперь работает корректно во всех случаях.